### PR TITLE
Update success indicators to avoid warning-like look (#7)

### DIFF
--- a/src/commands/firestore.ts
+++ b/src/commands/firestore.ts
@@ -41,11 +41,11 @@ async function firestore() {
 	if (exitCodeImport === 0) {
 		await execute(deleteFireStoreFolderBucket(projectId), () => {})
 		spinner.succeed('Import successful')
-		console.log(chalk.yellowBright('FireStore data imported 🔥🔥🔥🎉🎉🎉'))
+		console.log(chalk.greenBright('Firestore data imported 🎉'))
 		console.log(
-			chalk.green('Run following command to import data to firebase emulator')
+			chalk.cyanBright('Run following command to import data to Firebase emulator')
 		)
-		console.log(chalk.black.bgYellow(StartFirebaseEmulatorCommand))
+		console.log(chalk.bold.cyan(StartFirebaseEmulatorCommand))
 		spinner.stop()
 		// ! Remove firestore folder from the storage server
 	} else {


### PR DESCRIPTION
Closes #7

**Requirement**
🔥 + orange read as “error”

**Description**
- Success line now `chalk.greenBright('Firestore data imported 🎉')`
- Removed orange/🔥 to avoid warning-like look

**Test**
<img width="538" alt="image" src="https://github.com/user-attachments/assets/f3ae9d55-d2c6-4203-912f-04d631239efb" />

